### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on: 
   push:
     branches:    


### PR DESCRIPTION
Potential fix for [https://github.com/guylamar2006/Neothesia/security/code-scanning/6](https://github.com/guylamar2006/Neothesia/security/code-scanning/6)

Add an explicit top-level `permissions` block in `.github/workflows/build.yml` so all jobs inherit least-privilege token access unless overridden.

Best single fix without changing functionality:
- Insert, near the top of the workflow (after `name` and before `on`),:
  - `permissions:`
  - `  contents: read`

Why this is best:
- `actions/checkout` needs `contents: read`.
- No visible steps require write permissions.
- Root-level placement fixes all jobs at once and keeps behavior consistent.
- If a specific job later needs extra scopes, it can add a job-level `permissions` override.

No imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
